### PR TITLE
Separated _icons.scss into two files in order to fix IE11 issues

### DIFF
--- a/app/resources/scss/fonts/iconfont/_iconStyles.scss
+++ b/app/resources/scss/fonts/iconfont/_iconStyles.scss
@@ -1,0 +1,15 @@
+@mixin icon-styles {
+    position: relative;
+    font-family: "<%= fontName %>";
+    font-size: 68%;
+    line-height: 1;
+    font-style: normal;
+    font-variant: normal;
+    font-weight: normal;
+    text-decoration: none;
+    text-transform: none;
+    speak: none;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}

--- a/app/resources/scss/fonts/iconfont/_icons.scss
+++ b/app/resources/scss/fonts/iconfont/_icons.scss
@@ -7,22 +7,6 @@
     url('<%= fontPath %><%= fontName %>.svg#<%= fontName %>') format('svg');
 }
 
-@mixin icon-styles {
-    position: relative;
-    font-family: "<%= fontName %>";
-    font-size: 68%;
-    line-height: 1;
-    font-style: normal;
-    font-variant: normal;
-    font-weight: normal;
-    text-decoration: none;
-    text-transform: none;
-    speak: none;
-
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
-
 @function icon-char($filename) {
     $char: "";
 <% _.each(glyphs, function(glyph) { %>

--- a/app/resources/scss/styles.scss
+++ b/app/resources/scss/styles.scss
@@ -8,6 +8,7 @@
 
 /* fonts */
 @import "fonts/fonts";
+@import "../../../.iconfont/iconStyles";
 @import "../../../.iconfont/icons";
 
 /* breakpoint */

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "gulp": "3.9.1",
-    "gulp-build-framework": "https://github.com/virtualidentityag/gulp-build-framework.git#4.2.0",
+    "gulp-build-framework": "https://github.com/virtualidentityag/gulp-build-framework.git#4.3.0",
     "mocha": "^3.4.1",
     "require-dir": "0.3.1"
   },


### PR DESCRIPTION
This PR fixes [Issue #32](virtualidentityag/gulp-build-framework/issues/32) of the gulp-build-framework. It needs to be accepted together with the PR https://github.com/virtualidentityag/gulp-build-framework/pull/35

I am unsure, what the correct procedure for breaking changes is, but in order to use the changes, the new file _iconStyles.scss has to be added to existing projects and the _icons.css needs to be updated.